### PR TITLE
Remove deploy AWS Lambda dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.1.2 (2024/03/06)
 
 ### Pull Requests
-[#2](https://github.com/RafaelMoro/BE_Personal_Finances/pull/2) | Add development environment to AWS Lambda
+[#3](https://github.com/RafaelMoro/BE_Personal_Finances/pull/3) | Remove dev environment script.
 
 ## v0.1.1 (2024/03/06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.1.2 (2024/03/06)
+
+### Pull Requests
+[#2](https://github.com/RafaelMoro/BE_Personal_Finances/pull/2) | Add development environment to AWS Lambda
+
 ## v0.1.1 (2024/03/06)
 
 ### Pull Requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be_personal_finances",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "author": "",
   "private": true,
@@ -8,10 +8,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
-    "build:gcp": "tsc -p tsconfig.build.json",
-    "gcp-build": "npm run build",
     "deploy": "bun run build && sls deploy",
-    "deploy:dev": "bun run build && sls deploy --stage dev",
     "start": "node ./dist/main.js",
     "main": "node dist/main.js",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
## PR Description
Remove scripts to deploy into AWS Lambda dev environment.

If tried to have two separate yml's, it will deploy into the same lambda function overwritting it. This needs more investigation to be able to have two environments deployed in AWS in the same project.