### PR TITLE
Fix on local categories

### DIFF
--- a/src/categories/entities/categories.entity.ts
+++ b/src/categories/entities/categories.entity.ts
@@ -4,7 +4,7 @@ import { User } from '../../users/entities/users.entity';
 
 @Schema()
 export class Category extends Document {
-  @Prop({ required: true, unique: true })
+  @Prop({ required: true })
   categoryName: string;
 
   @Prop({ required: true })

--- a/src/categories/interface.ts
+++ b/src/categories/interface.ts
@@ -6,6 +6,12 @@ export interface CategoriesResponse extends Category {
   _id: Types.ObjectId;
 }
 
+export interface FindByNameAndUserIdProps {
+  categoryName: string;
+  userId: string;
+  isCreateLocalCategoriesService?: boolean;
+}
+
 export interface GeneralCategoriesResponse
   extends Omit<GeneralResponse, 'data'> {
   data: {

--- a/src/records/services/records.service.ts
+++ b/src/records/services/records.service.ts
@@ -64,7 +64,10 @@ export class RecordsService {
       const { category, amount } = data;
       const {
         data: { categories },
-      } = await this.categoriesService.findByNameAndUserId(category, userId);
+      } = await this.categoriesService.findByNameAndUserId({
+        categoryName: category,
+        userId,
+      });
       const [categoryFoundOrCreated] = categories;
       const { _id: categoryId } = categoryFoundOrCreated;
       const { fullDate, formattedTime } = formatDateToString(data.date);
@@ -382,7 +385,10 @@ export class RecordsService {
 
       const {
         data: { categories },
-      } = await this.categoriesService.findByNameAndUserId(category, userId);
+      } = await this.categoriesService.findByNameAndUserId({
+        categoryName: category,
+        userId,
+      });
       const [categoryFoundOrCreated] = categories;
       const { _id: categoryId, categoryName } = categoryFoundOrCreated;
       const { fullDate, formattedTime } = formatDateToString(date);


### PR DESCRIPTION
## PR Description
- Category name is not a unique prop anymore
- The service find by name and user id has been added the prop isCreateLocalCategoriesService where it will return a response instead of an error. This to know if local categories has been created. If not, the service will create them.
- This check is also for the service to create records where if the category name is not found, it will throw an error of category not found.