### PR TITLE
Fix to make create local categories public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.3.2 (2024/03/14)
+
+## Pull Requests
+[#10](https://github.com/RafaelMoro/BE_Personal_Finances/pull/10) |  Fix to make create local categories public
+
 ## v0.3.1 (2024/03/12)
 
 ### Pull Requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be_personal_finances",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "author": "",
   "private": true,

--- a/src/categories/controllers/categories.controller.ts
+++ b/src/categories/controllers/categories.controller.ts
@@ -12,9 +12,11 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { CategoriesService } from '../services/categories.service';
 import {
   CreateCategoriesDto,
+  CreateLocalCategoriesDto,
   DeleteCategoryDto,
   UpdateCategoriesDto,
 } from '../dtos/categories.dto';
+import { Public } from '../../auth/decorators/public.decorator';
 
 @UseGuards(JwtAuthGuard)
 @Controller('categories')
@@ -33,10 +35,11 @@ export class CategoriesController {
     return this.categoriesService.createOneCategory(payload, userId);
   }
 
+  @Public()
   @Post('create-local-categories')
-  createLocalCategories(@Request() req) {
-    const userId = req.user.sub;
-    return this.categoriesService.createLocalCategories(userId);
+  createLocalCategories(@Body() payload: CreateLocalCategoriesDto) {
+    const { sub } = payload;
+    return this.categoriesService.createLocalCategories(sub);
   }
 
   @Put()

--- a/src/categories/dtos/categories.dto.ts
+++ b/src/categories/dtos/categories.dto.ts
@@ -27,3 +27,9 @@ export class DeleteCategoryDto {
   @IsNotEmpty()
   readonly categoryId: string;
 }
+
+export class CreateLocalCategoriesDto {
+  @IsString()
+  @IsNotEmpty()
+  readonly sub: string;
+}

--- a/src/categories/services/categories.service.ts
+++ b/src/categories/services/categories.service.ts
@@ -131,13 +131,13 @@ export class CategoriesService {
     }
   }
 
-  async createLocalCategories(userId: string) {
+  async createLocalCategories(sub: string) {
     try {
       const [firstCategory] = ALL_LOCAL_CATEGORIES;
       const { categoryName } = firstCategory;
       const localCategoryExist = await this.findByNameAndUserId({
         categoryName,
-        userId,
+        userId: sub,
         isCreateLocalCategoriesService: true,
       });
       if (localCategoryExist.message !== CATEGORY_NOT_FOUND_ERROR) {
@@ -145,7 +145,7 @@ export class CategoriesService {
       }
 
       const localCategoriesModels = ALL_LOCAL_CATEGORIES.map((category) => {
-        return new this.categoryModel({ ...category, sub: userId });
+        return new this.categoryModel({ ...category, sub: sub });
       });
       const saveCategoriesModels = await Promise.all(
         localCategoriesModels.map((model) => model.save()),

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -85,12 +85,13 @@ export class UsersService {
       const passwordHashed = await bcrypt.hash(userModel.password, 10);
       userModel.password = passwordHashed;
       const modelSaved: UserResponse = await userModel.save();
-      const { email } = modelSaved.toJSON();
+      const responseCreateUser = modelSaved.toJSON();
+      const { email, _id: sub } = responseCreateUser;
       const response: CreateUserResponse = {
         version: VERSION_RESPONSE,
         success: true,
         message: USER_CREATED_MESSAGE,
-        data: { userCreated: { email } },
+        data: { userCreated: { email, sub } },
         error: null,
       };
       return response;

--- a/src/users/users.interface.ts
+++ b/src/users/users.interface.ts
@@ -7,7 +7,10 @@ export interface UserResponse extends User {
 }
 
 interface CreateUserResponseData {
-  userCreated: { email: string };
+  userCreated: {
+    email: string;
+    sub: string;
+  };
 }
 
 export interface CreateUserResponse extends Omit<GeneralResponse, 'data'> {


### PR DESCRIPTION
## PR Description
- The endpoint `/categories/create-local-categorie`s now accepts body:
```
{
  "sub": "userSub"
}
```

- The endpoint is now public
- The service to create a user now returns the prop sub