### PR TITLE
Add type of record prop into Record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.5.0 (2024/03/24)
+
+## Pull Requests
+[#12](https://github.com/RafaelMoro/BE_Personal_Finances/pull/12) | Add type of record prop into Record
+
 ## v0.4.0 (2024/03/21)
 
 ## Pull Requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be_personal_finances",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "author": "",
   "private": true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,5 +11,7 @@ export const INITIAL_RESPONSE: GeneralResponse = {
   error: null,
 };
 
+export type TypeOfRecord = 'expense' | 'income' | 'transfer';
+
 /** MESSAGED */
 export const USER_EXISTS_ERROR = 'Try with other email.';

--- a/src/records/constants/index.ts
+++ b/src/records/constants/index.ts
@@ -9,6 +9,11 @@ export const TRANSFER_RECORDS_NOT_FOUND = 'No transfer records found.';
 export const NO_EXPENSES_INCOMES_FOUND = 'No incomes or expenses found.';
 export const NO_EXPENSES_FOUND = 'No expenses found.';
 export const NO_INCOMES_FOUND = 'No incomes found.';
+export const TYPE_OF_RECORD_INVALID = 'Invalid type of record';
+export const TRANSFER_EMPTY_TRANSFERID_ERROR =
+  'Transfer record cannot have an empty transferId';
+export const INCOME_EXPENSE_TRANSFERID_ERROR =
+  'Record type income or expense cannot have a transferId';
 export const MISSING_DATE = 'date prop is missing.';
 export const MISSING_CATEGORY = 'category prop is missing.';
 export const MISSING_AMOUNT = 'amount prop is missing.';

--- a/src/records/dtos/records.dto.ts
+++ b/src/records/dtos/records.dto.ts
@@ -30,6 +30,10 @@ export class CreateRecordDto {
   readonly shortName: string;
 
   @IsString()
+  @IsNotEmpty()
+  readonly typeOfRecord: string;
+
+  @IsString()
   readonly description: string;
 
   @IsNumber()

--- a/src/records/entities/records.entity.ts
+++ b/src/records/entities/records.entity.ts
@@ -12,6 +12,9 @@ export class AccountRecord extends Document {
   @Prop({ required: true })
   shortName: string;
 
+  @Prop({ required: true })
+  typeOfRecord: string;
+
   @Prop()
   description: string;
 

--- a/src/utils/isTypeOfRecord.ts
+++ b/src/utils/isTypeOfRecord.ts
@@ -1,0 +1,5 @@
+import { TypeOfRecord } from '../constants';
+
+export function isTypeOfRecord(value: string): value is TypeOfRecord {
+  return value === 'expense' || value === 'income' || value === 'transfer';
+}


### PR DESCRIPTION
## PR Description
- Add typeOfRecord prop into Record entity and Dto
- Add validations where typeOfRecord cannot be different from "expense, income or transfer"
- Type of record income or expense cannot have a transferId validation error
- Add util fn to validate type of record is the type is expected
