### PR TITLE
Add Transfer record into record entity and DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.6.0 (2024/03/27)
+
+## Pull Requests
+[#13](https://github.com/RafaelMoro/BE_Personal_Finances/pull/13) | Add Transfer record into record entity and DTO
+
 ## v0.5.0 (2024/03/24)
 
 ## Pull Requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be_personal_finances",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "",
   "author": "",
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@codegenie/serverless-express':
+    specifier: ^4.13.0
+    version: 4.13.0
   '@nestjs-modules/mailer':
     specifier: 1.8.1
     version: 1.8.1(@nestjs/common@9.4.3)(@nestjs/core@9.4.3)(nodemailer@6.9.11)
@@ -82,9 +85,6 @@ dependencies:
     version: 4.6.3(express@4.18.3)
 
 devDependencies:
-  '@codegenie/serverless-express':
-    specifier: ^4.13.0
-    version: 4.13.0
   '@nestjs/cli':
     specifier: ^9.0.0
     version: 9.5.0
@@ -1198,7 +1198,7 @@ packages:
   /@codegenie/serverless-express@4.13.0:
     resolution: {integrity: sha512-xjTotGExm+2j45T6XTvDuTJO1105jKLf152j9nXXeJboYH3dwd8Ted6guv+jDFNouf0uKOO7AhGRQdCTpLVIiw==}
     engines: {node: '>=12'}
-    dev: true
+    dev: false
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}

--- a/src/records/constants/index.ts
+++ b/src/records/constants/index.ts
@@ -4,7 +4,6 @@ export const CATEGORY_ID_ERROR = 'Mongo Id does not belong to a category';
 export const RECORD_CREATED_MESSAGE = 'Record created';
 export const RECORD_DELETED = 'Record Deleted';
 export const RECORD_NOT_FOUND = 'Record not found.';
-export const TRANSFER_RECORDS_NOT_FOUND = 'No transfer records found.';
 
 export const NO_EXPENSES_INCOMES_FOUND = 'No incomes or expenses found.';
 export const NO_EXPENSES_FOUND = 'No expenses found.';
@@ -12,6 +11,8 @@ export const NO_INCOMES_FOUND = 'No incomes found.';
 export const TYPE_OF_RECORD_INVALID = 'Invalid type of record';
 export const TRANSFER_ACCOUNT_ERROR =
   'Income account and expense account must be different';
+export const TRANSFER_RECORDS_NOT_FOUND = 'No transfer records found.';
+export const MISSING_TRANSFER_RECORD = 'Transfer record is missing.';
 export const MISSING_DATE = 'date prop is missing.';
 export const MISSING_CATEGORY = 'category prop is missing.';
 export const MISSING_AMOUNT = 'amount prop is missing.';

--- a/src/records/constants/index.ts
+++ b/src/records/constants/index.ts
@@ -10,10 +10,6 @@ export const NO_EXPENSES_INCOMES_FOUND = 'No incomes or expenses found.';
 export const NO_EXPENSES_FOUND = 'No expenses found.';
 export const NO_INCOMES_FOUND = 'No incomes found.';
 export const TYPE_OF_RECORD_INVALID = 'Invalid type of record';
-export const TRANSFER_EMPTY_TRANSFERID_ERROR =
-  'Transfer record cannot have an empty transferId';
-export const INCOME_EXPENSE_TRANSFERID_ERROR =
-  'Record type income or expense cannot have a transferId';
 export const MISSING_DATE = 'date prop is missing.';
 export const MISSING_CATEGORY = 'category prop is missing.';
 export const MISSING_AMOUNT = 'amount prop is missing.';

--- a/src/records/constants/index.ts
+++ b/src/records/constants/index.ts
@@ -10,6 +10,8 @@ export const NO_EXPENSES_INCOMES_FOUND = 'No incomes or expenses found.';
 export const NO_EXPENSES_FOUND = 'No expenses found.';
 export const NO_INCOMES_FOUND = 'No incomes found.';
 export const TYPE_OF_RECORD_INVALID = 'Invalid type of record';
+export const TRANSFER_ACCOUNT_ERROR =
+  'Income account and expense account must be different';
 export const MISSING_DATE = 'date prop is missing.';
 export const MISSING_CATEGORY = 'category prop is missing.';
 export const MISSING_AMOUNT = 'amount prop is missing.';

--- a/src/records/controllers/records.controller.ts
+++ b/src/records/controllers/records.controller.ts
@@ -15,6 +15,7 @@ import { CreateIncomeDto, UpdateIncomeDto } from '../dtos/incomes.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RecordsService } from '../services/records.service';
 import { Param } from '@nestjs/common/decorators';
+import { CreateTransferDto } from '../dtos/transfer.dto';
 @UseGuards(JwtAuthGuard)
 @Controller('records')
 export class RecordsController {
@@ -30,6 +31,13 @@ export class RecordsController {
   createIncome(@Body() payload: CreateIncomeDto, @Request() req) {
     const userId = req.user.sub;
     return this.recordsService.createOneRecord(payload, true, userId);
+  }
+
+  @Post('/transfer')
+  createTransfer(@Body() payload: CreateTransferDto, @Request() req) {
+    const { expense, income } = payload;
+    const userId = req.user.sub;
+    return this.recordsService.createTransfer({ expense, income, userId });
   }
 
   @Get('/incomes/:accountId')

--- a/src/records/controllers/records.controller.ts
+++ b/src/records/controllers/records.controller.ts
@@ -113,13 +113,17 @@ export class RecordsController {
   @Put('/expenses')
   updateExpense(@Body() payload: UpdateExpenseDto, @Request() req) {
     const userId = req.user.sub;
-    return this.recordsService.updateRecord(payload, false, userId);
+    return this.recordsService.updateRecord({ changes: payload, userId });
   }
 
   @Put('/incomes')
   updateIncome(@Body() payload: UpdateIncomeDto, @Request() req) {
     const userId = req.user.sub;
-    return this.recordsService.updateRecord(payload, true, userId);
+    return this.recordsService.updateRecord({
+      changes: payload,
+      isIncome: true,
+      userId,
+    });
   }
 
   @Delete('/expenses')

--- a/src/records/dtos/records.dto.ts
+++ b/src/records/dtos/records.dto.ts
@@ -78,9 +78,6 @@ export class CreateRecordDto {
 
   @IsArray()
   readonly budgets: string[];
-
-  @IsString()
-  readonly transferId: string;
 }
 
 export class UpdateRecordDto extends PartialType(CreateRecordDto) {

--- a/src/records/dtos/records.dto.ts
+++ b/src/records/dtos/records.dto.ts
@@ -24,6 +24,14 @@ export class IndebtedPeople {
   isPaid: boolean;
 }
 
+export class TransferRecord {
+  @IsNotEmpty()
+  transferId: string;
+
+  @IsNotEmpty()
+  account: string;
+}
+
 export class CreateRecordDto {
   @IsString()
   @IsNotEmpty()
@@ -59,6 +67,10 @@ export class CreateRecordDto {
   @ValidateNested()
   @Type(() => IndebtedPeople)
   readonly indebtedPeople: IndebtedPeople[];
+
+  @ValidateNested()
+  @Type(() => TransferRecord)
+  readonly transferRecord: TransferRecord;
 
   @IsMongoId()
   @IsNotEmpty()

--- a/src/records/dtos/transfer.dto.ts
+++ b/src/records/dtos/transfer.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty } from 'class-validator';
+import { CreateExpenseDto } from './expenses.dto';
+import { CreateIncomeDto } from './incomes.dto';
+
+export class CreateTransferDto {
+  @IsNotEmpty()
+  readonly expense: CreateExpenseDto;
+
+  @IsNotEmpty()
+  readonly income: CreateIncomeDto;
+}

--- a/src/records/entities/records.entity.ts
+++ b/src/records/entities/records.entity.ts
@@ -67,9 +67,6 @@ export class AccountRecord extends Document {
 
   @Prop()
   budgets: string[];
-
-  @Prop()
-  transferId: string;
 }
 
 export const RecordsSchema = SchemaFactory.createForClass(AccountRecord);

--- a/src/records/entities/records.entity.ts
+++ b/src/records/entities/records.entity.ts
@@ -1,4 +1,4 @@
-import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Prop, Schema, SchemaFactory, raw } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 
 import { Account } from '../../accounts/entities/accounts.entity';
@@ -53,6 +53,14 @@ export class AccountRecord extends Document {
     ],
   })
   indebtedPeople: Types.Array<Record<'string | boolean | number', any>>;
+
+  @Prop(
+    raw({
+      transferId: { type: String },
+      account: { type: String },
+    }),
+  )
+  transferRecord: Record<string, any>;
 
   @Prop({ type: Types.ObjectId, ref: Account.name, required: true })
   account: Account | Types.ObjectId;

--- a/src/records/interface.ts
+++ b/src/records/interface.ts
@@ -57,6 +57,13 @@ export interface RecordCreated extends Omit<GeneralResponse, 'category'> {
   };
 }
 
+export interface TransferCreated extends Omit<GeneralResponse, 'category'> {
+  data: {
+    expense: Expense;
+    income: Income;
+  };
+}
+
 export interface JoinRecordsResponse extends Omit<GeneralResponse, 'data'> {
   data: {
     records: (Expense | Income)[];

--- a/src/records/interface.ts
+++ b/src/records/interface.ts
@@ -2,12 +2,20 @@ import { Expense } from './entities/expenses.entity';
 import { DeleteRecordDto } from './dtos/records.dto';
 import { GeneralResponse } from 'src/response.interface';
 import { Income } from './entities/incomes.entity';
+import { CreateIncomeDto } from './dtos/incomes.dto';
+import { CreateExpenseDto } from './dtos/expenses.dto';
 
 /** Interfaces of services */
 export interface FindRecordsByAccountProps {
   accountId: string;
   userId: string;
   isIncome?: boolean;
+}
+
+export interface CreateTransferProps {
+  expense: CreateExpenseDto;
+  income: CreateIncomeDto;
+  userId: string;
 }
 
 export interface FindTransferRecordsByMonthAndYearProps {

--- a/src/records/interface.ts
+++ b/src/records/interface.ts
@@ -53,6 +53,12 @@ export interface FindTransferRecordsResponse
   };
 }
 
+export interface UpdateRecordResponse extends Omit<GeneralResponse, 'data'> {
+  data: {
+    record: Expense | Income;
+  };
+}
+
 export interface MultipleRecordsResponse extends Omit<GeneralResponse, 'data'> {
   data: {
     records: Expense[] | Income[] | (Expense | Income)[] | null;

--- a/src/records/interface.ts
+++ b/src/records/interface.ts
@@ -2,14 +2,22 @@ import { Expense } from './entities/expenses.entity';
 import { DeleteRecordDto } from './dtos/records.dto';
 import { GeneralResponse } from 'src/response.interface';
 import { Income } from './entities/incomes.entity';
-import { CreateIncomeDto } from './dtos/incomes.dto';
-import { CreateExpenseDto } from './dtos/expenses.dto';
+import { CreateIncomeDto, UpdateIncomeDto } from './dtos/incomes.dto';
+import { CreateExpenseDto, UpdateExpenseDto } from './dtos/expenses.dto';
 
 /** Interfaces of services */
 export interface FindRecordsByAccountProps {
   accountId: string;
   userId: string;
   isIncome?: boolean;
+}
+
+export interface UpdateRecordProps {
+  changes: UpdateIncomeDto | UpdateExpenseDto;
+  isIncome?: boolean;
+  userId: string;
+  skipFindCategory?: boolean;
+  skipUpdateExpensesPaid?: boolean;
 }
 
 export interface CreateTransferProps {

--- a/src/records/services/records.service.ts
+++ b/src/records/services/records.service.ts
@@ -27,8 +27,6 @@ import {
   MISSING_AMOUNT,
   RECORD_DELETED,
   TRANSFER_RECORDS_NOT_FOUND,
-  TRANSFER_EMPTY_TRANSFERID_ERROR,
-  INCOME_EXPENSE_TRANSFERID_ERROR,
   TYPE_OF_RECORD_INVALID,
 } from '../constants';
 import {
@@ -159,7 +157,10 @@ export class RecordsService {
       });
       const [categoryFoundOrCreated] = categories;
       const { _id: categoryId } = categoryFoundOrCreated;
-      const { fullDate, formattedTime } = formatDateToString(expense.date);
+      // @TODO: Check if parsing the date as string into date is needed
+      const { fullDate, formattedTime } = formatDateToString(
+        new Date(expense.date),
+      );
       const amountFormatted = formatNumberToCurrency(amount);
       const newDataExpense = {
         ...expense,

--- a/src/records/services/records.service.ts
+++ b/src/records/services/records.service.ts
@@ -29,6 +29,7 @@ import {
   TRANSFER_RECORDS_NOT_FOUND,
   TYPE_OF_RECORD_INVALID,
   TRANSFER_ACCOUNT_ERROR,
+  MISSING_TRANSFER_RECORD,
 } from '../constants';
 import {
   FindRecordsByAccountProps,
@@ -273,6 +274,11 @@ export class RecordsService {
           select: '_id categoryName icon',
         },
       );
+
+      // Validation if any of the transfer records has a missing transfer record
+      if (!expensePopulated.transferRecord || !incomePopulated.transferRecord) {
+        throw new BadRequestException(MISSING_TRANSFER_RECORD);
+      }
 
       const response: TransferCreated = {
         version: VERSION_RESPONSE,

--- a/src/records/services/records.service.ts
+++ b/src/records/services/records.service.ts
@@ -70,15 +70,9 @@ export class RecordsService {
     userId: string,
   ) {
     try {
-      const { category, amount, typeOfRecord, transferId } = data;
+      const { category, amount, typeOfRecord } = data;
       if (isTypeOfRecord(typeOfRecord) === false) {
         throw new BadRequestException(TYPE_OF_RECORD_INVALID);
-      }
-      if (typeOfRecord === 'transfer' && !transferId) {
-        throw new BadRequestException(TRANSFER_EMPTY_TRANSFERID_ERROR);
-      }
-      if (typeOfRecord !== 'transfer' && transferId) {
-        throw new BadRequestException(INCOME_EXPENSE_TRANSFERID_ERROR);
       }
 
       const {

--- a/src/records/services/records.service.ts
+++ b/src/records/services/records.service.ts
@@ -28,6 +28,7 @@ import {
   RECORD_DELETED,
   TRANSFER_RECORDS_NOT_FOUND,
   TYPE_OF_RECORD_INVALID,
+  TRANSFER_ACCOUNT_ERROR,
 } from '../constants';
 import {
   FindRecordsByAccountProps,
@@ -151,12 +152,17 @@ export class RecordsService {
   async createTransfer({ expense, income, userId }: CreateTransferProps) {
     try {
       const { category, amount, typeOfRecord } = expense;
+
+      // Validations
       if (
         expense.typeOfRecord !== 'transfer' ||
         income.typeOfRecord !== 'transfer' ||
         isTypeOfRecord(typeOfRecord) === false
       ) {
         throw new BadRequestException(TYPE_OF_RECORD_INVALID);
+      }
+      if (expense.account === income.account) {
+        throw new BadRequestException(TRANSFER_ACCOUNT_ERROR);
       }
 
       const {

--- a/src/records/services/records.service.ts
+++ b/src/records/services/records.service.ts
@@ -71,7 +71,14 @@ export class RecordsService {
   ) {
     try {
       const { category, amount, typeOfRecord } = data;
-      if (isTypeOfRecord(typeOfRecord) === false) {
+      if (
+        isTypeOfRecord(typeOfRecord) === false ||
+        typeOfRecord === 'transfer' ||
+        // Validate if the record is an expense and type of record has value income
+        (!isIncome && typeOfRecord === 'income') ||
+        // Validate if the record is an income and type of record has value expense
+        (isIncome && typeOfRecord === 'expense')
+      ) {
         throw new BadRequestException(TYPE_OF_RECORD_INVALID);
       }
 
@@ -145,8 +152,9 @@ export class RecordsService {
     try {
       const { category, amount, typeOfRecord } = expense;
       if (
-        isTypeOfRecord(expense.typeOfRecord) === false &&
-        isTypeOfRecord(income.typeOfRecord) === false
+        expense.typeOfRecord !== 'transfer' ||
+        income.typeOfRecord !== 'transfer' ||
+        isTypeOfRecord(typeOfRecord) === false
       ) {
         throw new BadRequestException(TYPE_OF_RECORD_INVALID);
       }


### PR DESCRIPTION
## PR Description
- Delete transferId prop
- Add Transfer Record that involves: TransferId and account
- Add interface props into update record service
- Change interface of the response of update record service
- Add validations:
    - When creating an expense, type of record cannot be different of expense
    - When creating an income, type of record cannot be different of income
    - When creating an transfer, type of record cannot be different of transfer
    - When creating a transfer, the account cannot be the same of the income and the expense
    - When creating a transfer, If the expense or income has an empty transfer Id, it will throw an error