### PR TITLE
Update to v0.6.8 changelog and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.6.7 (2024/04/04)
+## v0.6.8 (2024/04/04)
 
 ### Changes
 - Delete date prop transformed with timezone when saving it into db when creating and updating transfers and records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.6.7 (2024/04/04)
+
+### Changes
+- Delete date prop transformed with timezone when saving it into db when creating and updating transfers and records
+
 ## v0.6.7 (2024/03/31)
 
 ### Pull Requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be_personal_finances",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
## PR Description
Update to v0.6.8

### Changes
- Delete date prop transformed with timezone when saving it into db when creating and updating transfers and records